### PR TITLE
MI-441: Store meeting metadata in DB

### DIFF
--- a/server/model/survey.go
+++ b/server/model/survey.go
@@ -7,10 +7,11 @@ import (
 )
 
 const (
-	TypeSurvey           = "survey"
-	TypeSurveyResponse   = "survey_response"
-	TypeMeetingMetadata  = "meeting_metadata"
-	TypeLatestSurveyInfo = "latest_survey_info"
+	TypeSurvey              = "survey"
+	TypeSurveyResponse      = "survey_response"
+	TypeMeetingMetadata     = "meeting_metadata"
+	TypeLatestSurveyInfo    = "latest_survey_info"
+	TypeUserMeetingMetadata = "user_meeting_metadata"
 
 	QuestionTypeOpen                 = "open"
 	QuestionTypeFivePointLikertScale = "five-point-likert-scale"
@@ -123,11 +124,10 @@ func DecodeSurveyResponseFromByte(b []byte) *SurveyResponse {
 
 // MeetingMetadata stores the survey metadata for a  meeting
 type MeetingMetadata struct {
-	Type          string          `json:"type"`
-	MeetingID     string          `json:"meeting_id"`
-	SurveyID      string          `json:"survey_id"`
-	SurveyVersion int             `json:"survey_version"`
-	UserResponded map[string]bool `json:"user_responded"`
+	Type          string `json:"type"`
+	MeetingID     string `json:"meeting_id"`
+	SurveyID      string `json:"survey_id"`
+	SurveyVersion int    `json:"survey_version"`
 }
 
 func (m *MeetingMetadata) PreSave() *MeetingMetadata {
@@ -149,6 +149,36 @@ func DecodeMeetingMetadataFromByte(b []byte) *MeetingMetadata {
 		return nil
 	}
 	return &m
+}
+
+// UserMeetingMetadata stores the user metadata for a  meeting
+type UserMeetingMetadata struct {
+	Type         string `json:"type"`
+	UserID       string `json:"user_id"`
+	MeetingID    string `json:"meeting_id"`
+	SurveySentAt int64  `json:"survey_sent_at"`
+	RespondedAt  int64  `json:"responded_at"`
+}
+
+func (u *UserMeetingMetadata) PreSave() *UserMeetingMetadata {
+	u.Type = TypeUserMeetingMetadata
+	return u
+}
+
+// EncodeToByte returns a user meeting metadata as a byte array
+func (u *UserMeetingMetadata) EncodeToByte() []byte {
+	b, _ := json.Marshal(u)
+	return b
+}
+
+// DecodeUserMeetingMetadataFromByte tries to create a user meeting metadata from a byte array
+func DecodeUserMeetingMetadataFromByte(b []byte) *UserMeetingMetadata {
+	u := UserMeetingMetadata{}
+	err := json.Unmarshal(b, &u)
+	if err != nil {
+		return nil
+	}
+	return &u
 }
 
 // LatestSurveyInfo stores the latest version information for a survey

--- a/server/model/survey.go
+++ b/server/model/survey.go
@@ -123,11 +123,11 @@ func DecodeSurveyResponseFromByte(b []byte) *SurveyResponse {
 
 // MeetingMetadata stores the survey metadata for a  meeting
 type MeetingMetadata struct {
-	Type          string
-	MeetingID     string
-	SurveyID      string
-	SurveyVersion int
-	UserResponded map[string]bool
+	Type          string          `json:"type"`
+	MeetingID     string          `json:"meeting_id"`
+	SurveyID      string          `json:"survey_id"`
+	SurveyVersion int             `json:"survey_version"`
+	UserResponded map[string]bool `json:"user_responded"`
 }
 
 func (m *MeetingMetadata) PreSave() *MeetingMetadata {

--- a/server/model/survey.go
+++ b/server/model/survey.go
@@ -130,6 +130,27 @@ type MeetingMetadata struct {
 	UserResponded map[string]bool
 }
 
+func (m *MeetingMetadata) PreSave() *MeetingMetadata {
+	m.Type = TypeMeetingMetadata
+	return m
+}
+
+// EncodeToByte returns a meeting metadata as a byte array
+func (m *MeetingMetadata) EncodeToByte() []byte {
+	b, _ := json.Marshal(m)
+	return b
+}
+
+// DecodeMeetingMetadataFromByte tries to create a meeting metadata from a byte array
+func DecodeMeetingMetadataFromByte(b []byte) *MeetingMetadata {
+	m := MeetingMetadata{}
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return nil
+	}
+	return &m
+}
+
 // LatestSurveyInfo stores the latest version information for a survey
 type LatestSurveyInfo struct {
 	Type          string `json:"type"`

--- a/server/platform/metadata.go
+++ b/server/platform/metadata.go
@@ -1,0 +1,52 @@
+package platform
+
+import (
+	"github.com/Brightscout/mattermost-plugin-survey/server/config"
+	"github.com/Brightscout/mattermost-plugin-survey/server/model"
+)
+
+// GetMeetingMetadata returns the survey metadata for a meeting with a given meetingID.
+// Returns the meetingMetadata if found and nil if not.
+func GetMeetingMetadata(meetingID string) *model.MeetingMetadata {
+	meetingMetadata, err := config.Store.GetMeetingMetadata(meetingID)
+	if err != nil {
+		config.Mattermost.LogError("Unable to get meeting metadata.", "MeetingID", meetingID, "Error", err.Error())
+		return nil
+	}
+	return meetingMetadata
+}
+
+// SaveMeetingMetadata saves the survey metadata for a meeting.
+func SaveMeetingMetadata(meetingID, surveyID string, surveyVersion int) error {
+	m := &model.MeetingMetadata{
+		MeetingID:     meetingID,
+		SurveyID:      surveyID,
+		SurveyVersion: surveyVersion,
+	}
+	m = m.PreSave()
+	if err := config.Store.SaveMeetingMetadata(m); err != nil {
+		config.Mattermost.LogError("Failed to save the meeting metadata.", "MeetingID", meetingID, "SurveyID", surveyID, "SurveyVersion", surveyVersion, "Error", err.Error())
+		return err
+	}
+	return nil
+}
+
+// GetUserMeetingMetadata returns the user metadata for a meeting with a given userID and meetingID.
+// Returns the userMeetingMetadata if found and nil if not.
+func GetUserMeetingMetadata(userID, meetingID string) *model.UserMeetingMetadata {
+	userMeetingMetadata, err := config.Store.GetUserMeetingMetadata(userID, meetingID)
+	if err != nil {
+		config.Mattermost.LogError("Unable to get meeting metadata.", "UserID", userID, "MeetingID", meetingID, "Error", err.Error())
+		return nil
+	}
+	return userMeetingMetadata
+}
+
+// SaveUserMeetingMetadata saves the user metadata for a meeting.
+func SaveUserMeetingMetadata(u *model.UserMeetingMetadata) error {
+	u = u.PreSave()
+	if err := config.Store.SaveUserMeetingMetadata(u); err != nil {
+		config.Mattermost.LogError("Failed to save the user meeting metadata.", "Error", err.Error())
+	}
+	return nil
+}

--- a/server/store/kvstore/survey.go
+++ b/server/store/kvstore/survey.go
@@ -54,12 +54,20 @@ func (s *KVStore) SaveSurvey(survey *model.Survey) error {
 }
 
 func (s *KVStore) GetMeetingMetadata(meetingID string) (*model.MeetingMetadata, error) {
-	// TODO: Implement this method
-	return nil, nil
+	key := MeetingMetadataKey(meetingID)
+	b, err := config.Mattermost.KVGet(key)
+	if err != nil {
+		return nil, err
+	}
+	m := model.DecodeMeetingMetadataFromByte(b)
+	return m, nil
 }
 
 func (s *KVStore) SaveMeetingMetadata(data *model.MeetingMetadata) error {
-	// TODO: Implement this method
+	key := MeetingMetadataKey(data.MeetingID)
+	if err := config.Mattermost.KVSet(key, data.EncodeToByte()); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/server/store/kvstore/survey.go
+++ b/server/store/kvstore/survey.go
@@ -71,6 +71,24 @@ func (s *KVStore) SaveMeetingMetadata(data *model.MeetingMetadata) error {
 	return nil
 }
 
+func (s *KVStore) GetUserMeetingMetadata(userID, meetingID string) (*model.UserMeetingMetadata, error) {
+	key := UserMeetingMetadataKey(userID, meetingID)
+	b, err := config.Mattermost.KVGet(key)
+	if err != nil {
+		return nil, err
+	}
+	u := model.DecodeUserMeetingMetadataFromByte(b)
+	return u, nil
+}
+
+func (s *KVStore) SaveUserMeetingMetadata(data *model.UserMeetingMetadata) error {
+	key := UserMeetingMetadataKey(data.UserID, data.MeetingID)
+	if err := config.Mattermost.KVSet(key, data.EncodeToByte()); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *KVStore) SaveSurveyResponse(response *model.SurveyResponse) error {
 	key := SurveyResponseKey(response.UserID, response.MeetingID, response.SurveyID, strconv.Itoa(response.SurveyVersion))
 	if err := config.Mattermost.KVSet(key, response.EncodeToByte()); err != nil {

--- a/server/store/kvstore/util.go
+++ b/server/store/kvstore/util.go
@@ -7,28 +7,34 @@ import (
 )
 
 const (
-	LatestSurveyKeyPrefix    = "latest_survey_"
-	SurveyKeyPrefix          = "survey_"
-	SurveyResponseKeyPrefix  = "survey_response_"
-	MeetingMetadataKeyPrefix = "meeting_metadata_"
+	latestSurveyKeyPrefix        = "latest_survey_"
+	surveyKeyPrefix              = "survey_"
+	surveyResponseKeyPrefix      = "survey_response_"
+	meetingMetadataKeyPrefix     = "meeting_metadata_"
+	userMeetingMetadataKeyPrefix = "user_meeting_metadata_"
 )
 
 func LatestSurveyKey(surveyID string) string {
-	key := fmt.Sprintf("%s%s", LatestSurveyKeyPrefix, surveyID)
+	key := fmt.Sprintf("%s%s", latestSurveyKeyPrefix, surveyID)
 	return util.GetKeyHash(key)
 }
 
 func SurveyKey(surveyID, surveyVersion string) string {
-	key := fmt.Sprintf("%s%s_%s", SurveyKeyPrefix, surveyID, surveyVersion)
+	key := fmt.Sprintf("%s%s_%s", surveyKeyPrefix, surveyID, surveyVersion)
 	return util.GetKeyHash(key)
 }
 
 func SurveyResponseKey(userID, meetingID, surveyID, surveyVersion string) string {
-	key := fmt.Sprintf("%s%s_%s_%s_%s", SurveyResponseKeyPrefix, userID, meetingID, surveyID, surveyVersion)
+	key := fmt.Sprintf("%s%s_%s_%s_%s", surveyResponseKeyPrefix, userID, meetingID, surveyID, surveyVersion)
 	return util.GetKeyHash(key)
 }
 
 func MeetingMetadataKey(meetingID string) string {
-	key := fmt.Sprintf("%s%s", MeetingMetadataKeyPrefix, meetingID)
+	key := fmt.Sprintf("%s%s", meetingMetadataKeyPrefix, meetingID)
+	return util.GetKeyHash(key)
+}
+
+func UserMeetingMetadataKey(userID, meetingID string) string {
+	key := fmt.Sprintf("%s%s_%s", meetingMetadataKeyPrefix, userID, meetingID)
 	return util.GetKeyHash(key)
 }

--- a/server/store/kvstore/util.go
+++ b/server/store/kvstore/util.go
@@ -35,6 +35,6 @@ func MeetingMetadataKey(meetingID string) string {
 }
 
 func UserMeetingMetadataKey(userID, meetingID string) string {
-	key := fmt.Sprintf("%s%s_%s", meetingMetadataKeyPrefix, userID, meetingID)
+	key := fmt.Sprintf("%s%s_%s", userMeetingMetadataKeyPrefix, userID, meetingID)
 	return util.GetKeyHash(key)
 }

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -12,5 +12,7 @@ type SurveyStore interface {
 	SaveSurvey(survey *model.Survey) error
 	GetMeetingMetadata(meetingID string) (*model.MeetingMetadata, error)
 	SaveMeetingMetadata(data *model.MeetingMetadata) error
+	GetUserMeetingMetadata(userID, meetingID string) (*model.UserMeetingMetadata, error)
+	SaveUserMeetingMetadata(data *model.UserMeetingMetadata) error
 	SaveSurveyResponse(response *model.SurveyResponse) error
 }

--- a/webapp/src/components/survey_modal/survey_modal.jsx
+++ b/webapp/src/components/survey_modal/survey_modal.jsx
@@ -144,7 +144,7 @@ export default class SurveyModal extends React.PureComponent {
                     <ButtonGroup className='float-right'>
                         <Button
                             type='button'
-                            bsStyle='secondary'
+                            bsStyle='info'
                             onClick={this.handleClose}
                         >
                             {'Cancel'}


### PR DESCRIPTION
#### Summary
- Add models for `UserMeetingMetadata` and helper methods to store meeting and user metadata in DB.
- Check the meeting metadata to select which survey to send to the User. Add a condition to send the latest survey if meeting metadata does not exist.
- Create the meeting metadata object after sending the latest survey if it did not exist.
- Update user metadata with time when the user was sent the survey.
- Check if the survey was sent to the user when accepting a response from the user.
- Update user metadata with time when the user responded to the survey.