### PR TITLE
MI-1005: Select meeting metrics tab by default

### DIFF
--- a/webapp/src/actions/dashboard.js
+++ b/webapp/src/actions/dashboard.js
@@ -4,5 +4,8 @@ export const openRiffDashboard = (meetingID) => (dispatch) => {
     dispatch({
         type: Constants.ACTION_TYPES.OPEN_RIFF_DASHBOARD,
         meetingID,
+
+        // Always show meeting-specific metrics when showing from the survey post link
+        selectedMetrics: Constants.METRICS_TYPE_MEETING_METRICS,
     });
 };

--- a/webapp/src/constants/index.js
+++ b/webapp/src/constants/index.js
@@ -50,4 +50,5 @@ export default {
     OPEN_QUESTION_MAX_LENGTH,
     PLUGIN_NAME,
     QUESTION_TYPES,
+    METRICS_TYPE_MEETING_METRICS: 'meetingMetrics',
 };


### PR DESCRIPTION
_copied from @chetanyakan 's description for this change in the https://github.com/Brightscout/mattermost-plugin-riff-survey/pull/11 PR._

#### Summary
* Pass the selected metric type with dispatch the action to open the riff dashboard.
* Always set the metrics type to meeting metrics for the survey post.
 
Refer: [rifflearning/mattermost-plugin-riff-core#25](https://github.com/rifflearning/mattermost-plugin-riff-core/pull/25)
